### PR TITLE
BREAKING: automatically determine partial theme type

### DIFF
--- a/src/createThemeProvider.js
+++ b/src/createThemeProvider.js
@@ -4,20 +4,16 @@ import * as React from 'react';
 
 import type { Context } from 'create-react-context';
 
-type ThemeProviderProps<T> = {
-  children?: any,
-  theme: T,
-};
-
-export type ThemeProviderType<T> = React.ComponentType<ThemeProviderProps<T>>;
+export type ThemeProviderType<T> = React.ComponentType<{
+  children: React.Node,
+  theme?: T,
+}>;
 
 function createThemeProvider<T>(
   defaultTheme: T,
   ThemeContext: Context<T>
 ): ThemeProviderType<T> {
-  return class ThemeProvider extends React.PureComponent<
-    ThemeProviderProps<T>
-  > {
+  return class ThemeProvider extends React.Component<*> {
     static defaultProps = {
       theme: defaultTheme,
     };

--- a/src/createTheming.js
+++ b/src/createTheming.js
@@ -6,21 +6,21 @@ import createWithTheme from './createWithTheme';
 import type { WithThemeType } from './createWithTheme';
 import type { ThemeProviderType } from './createThemeProvider';
 
-export type ThemingType<T, S> = {
+export type ThemingType<T> = {
   ThemeProvider: ThemeProviderType<T>,
-  withTheme: WithThemeType<T, S>,
+  withTheme: WithThemeType<T>,
 };
 
-export default function createTheming<T, S>(
+export default function createTheming<T: Object>(
   defaultTheme: T
-): ThemingType<T, S> {
+): ThemingType<T> {
   const ThemeContext: Context<T> = createReactContext(defaultTheme);
 
   const ThemeProvider: ThemeProviderType<T> = createThemeProvider(
     defaultTheme,
     ThemeContext
   );
-  const withTheme: WithThemeType<T, S> = createWithTheme(
+  const withTheme: WithThemeType<T> = createWithTheme(
     ThemeProvider,
     ThemeContext
   );

--- a/typings/__tests__/index.test.tsx
+++ b/typings/__tests__/index.test.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { createTheming } from "../..";
 
-export type Theme = {
+type Theme = {
   primaryColor: string;
   accentColor: string;
   backgroundColor: string;
@@ -9,11 +9,7 @@ export type Theme = {
   secondaryColor: string;
 };
 
-export type PartialTheme = {
-  primaryColor?: string;
-};
-
-export const themes: { [key: string]: Theme } = {
+const themes: { [key: string]: Theme } = {
   default: {
     primaryColor: "#FFA72A",
     accentColor: "#458622",
@@ -30,7 +26,7 @@ export const themes: { [key: string]: Theme } = {
   }
 };
 
-const { ThemeProvider, withTheme } = createTheming<Theme, PartialTheme>(
+const { ThemeProvider, withTheme } = createTheming<Theme>(
   themes.default
 );
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,26 +1,22 @@
 // Type definitions for @callstack/react-theme-provider 1.0.2
 // TypeScript version 3.0.3
 
-import * as React from "react";
+import * as React from 'react';
 
-type Without<T, K> = Pick<T, Exclude<keyof T, K>>;
+type $Without<T, K> = Pick<T, Exclude<keyof T, K>>;
+type $DeepPartial<T> = { [P in keyof T]?: $DeepPartial<T[P]> };
 
-export type ThemeProviderType<Theme> = React.ComponentType<{ theme: Theme }>;
-
-export type ThemingType<Theme, PartialTheme> = {
-  ThemeProvider: ThemeProviderType<Theme>;
+export type ThemingType<Theme> = {
+  ThemeProvider: React.ComponentType<{ theme?: Theme }>;
   withTheme: <Props extends { theme: Theme }>(
     Comp: React.ComponentType<Props>
-  ) => React.ComponentType<Without<Props, "theme"> & { theme?: PartialTheme }>;
+  ) => React.ComponentType<
+    $Without<Props, 'theme'> & { theme?: $DeepPartial<Theme> }
+  >;
 };
 
 // Library exports
-export const ThemeProvider: ThemeProviderType<{}>;
+export const ThemeProvider: ThemingType<object>['ThemeProvider'];
+export const withTheme: ThemingType<object>['withTheme'];
 
-export const withTheme: <Props extends { theme: {} }>(
-  Comp: React.ComponentType<Props>
-) => React.ComponentType<Without<Props, "theme">>;
-
-export const createTheming: <Theme, PartialTheme>(
-  defaultTheme: Theme
-) => ThemingType<Theme, PartialTheme>;
+export const createTheming: <Theme>(defaultTheme: Theme) => ThemingType<Theme>;


### PR DESCRIPTION
Previously we accepted 2 type parameters, one for the full theme and one for the partial theme. This commit adds automatic type checking for the partial theme without having to specify it, both for Flow and TypeScript.