### PR TITLE
add useTheme to ThemingType

### DIFF
--- a/src/createTheming.js
+++ b/src/createTheming.js
@@ -11,6 +11,7 @@ import type { $DeepShape } from './types';
 export type ThemingType<T> = {
   ThemeProvider: ThemeProviderType<T>,
   withTheme: WithThemeType<T>,
+  useTheme(overrides?: $DeepShape<T>): T,
 };
 
 export default function createTheming<T: Object>(


### PR DESCRIPTION
### Summary

Currently, Flow will yell loudly if you try to use `useTheme` from the result of `createTheming`; with this change, it's happy.

### Test plan

Before, if you did 

```
const {ThemeProvider, withTheme, useTheme} = createTheming(theme)
```

in a Flow project, you would get "unknown item `useTheme`".

With this change, Flow is silent, and properly assumes the return of a T-shaped object from useTheme.