### PR TITLE
refactor: drop wrapper provider for components wrapped in withTheme

### DIFF
--- a/src/createWithTheme.js
+++ b/src/createWithTheme.js
@@ -41,23 +41,13 @@ const createWithTheme = <T: Object, S: $DeepShape<T>>(
 
         return (
           <ThemeContext.Consumer>
-            {theme => {
-              const merged = this._merge(theme, rest.theme);
-              const element = (
-                <Comp
-                  {...rest}
-                  theme={merged}
-                  ref={_reactThemeProviderForwardedRef}
-                />
-              );
-
-              if (rest.theme && merged !== rest.theme) {
-                // If a theme prop was passed, expose it to the children
-                return <ThemeProvider theme={merged}>{element}</ThemeProvider>;
-              }
-
-              return element;
-            }}
+            {theme => (
+              <Comp
+                {...rest}
+                theme={this._merge(theme, rest.theme)}
+                ref={_reactThemeProviderForwardedRef}
+              />
+            )}
           </ThemeContext.Consumer>
         );
       }


### PR DESCRIPTION
BREAKING CHANGE:

Previously if the theme differed from the one in context, we wrapped the component in a provider as well. However, most components don't need it and it can be confusing when trying to override the theme for only specific component.

This commit drops this extra wrapper. The old behaviour can still be achieved by explicitly using a `ThemeProvider` instead of a `theme` prop.