### PR TITLE
fix: wrong imports on the readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ yarn add @callstack/react-theme-provider
 Import `createTheming` from the library to create a theming object.
 
 ```js
-import { createTheming } from '@callstack/theme-provider';
+import { createTheming } from '@callstack/react-theme-provider';
 
 const { ThemeProvider, withTheme, useTheme } = createTheming(defaultTheme);
 ```


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary
In the documentation, the first example for importing the library is not using the correct path. This will allow people to have errors since the package does not exist.


