### PR TITLE
Package @types/hoist-non-react-statics must be a regular dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "@babel/preset-flow": "^7.0.0",
     "@babel/preset-react": "^7.0.0",
     "@callstack/eslint-config": "^3.0.2",
-    "@types/hoist-non-react-statics": "^3.3.1",
     "@types/react": "^16.8.8",
     "eslint": "^5.15.1",
     "flow-bin": "^0.94.0",
@@ -55,6 +54,7 @@
     "react": "^16.3.0"
   },
   "dependencies": {
+    "@types/hoist-non-react-statics": "^3.3.1",
     "deepmerge": "^3.2.0",
     "hoist-non-react-statics": "^3.3.0"
   },


### PR DESCRIPTION
To avoid to add @types/hoist-non-react-statics to the "hosting" project the 
@types/hoist-non-react-statics package must be included as a regular dependency.

### Summary

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
