### PR TITLE
Export ThemeContext

### DIFF
--- a/src/createTheming.js
+++ b/src/createTheming.js
@@ -41,6 +41,7 @@ export default function createTheming<T: Object>(
   };
 
   return {
+    ThemeContext,
     ThemeProvider,
     withTheme,
     useTheme,


### PR DESCRIPTION
We'd like to use ThemeContext in order to work with `ThemeContext.Consumer` component, as well as `static contextType = ThemeContext`. Which is not possible with the current implementation.

### Summary

Added `ThemeContext` to `createTheming.js` exported properties.

### Test plan

```js
assert(import('@callstack/theme-provider').createTheming().ThemeContext !== undefined);
```
