### PR TITLE
fix: use own copy of types for hoist-non-react-statics package

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     "react": "^16.3.0"
   },
   "dependencies": {
-    "@types/hoist-non-react-statics": "^3.3.1",
     "deepmerge": "^3.2.0",
     "hoist-non-react-statics": "^3.3.0"
   },

--- a/typings/__tests__/index.test.tsx
+++ b/typings/__tests__/index.test.tsx
@@ -1,5 +1,5 @@
-import * as React from "react";
-import { createTheming } from "../..";
+import * as React from 'react';
+import { createTheming } from '../..';
 
 type Theme = {
   primaryColor: string;
@@ -11,24 +11,22 @@ type Theme = {
 
 const themes: { [key: string]: Theme } = {
   default: {
-    primaryColor: "#FFA72A",
-    accentColor: "#458622",
-    backgroundColor: "#FFC777",
-    textColor: "#504f4d",
-    secondaryColor: "#7F5315"
+    primaryColor: '#FFA72A',
+    accentColor: '#458622',
+    backgroundColor: '#FFC777',
+    textColor: '#504f4d',
+    secondaryColor: '#7F5315',
   },
   dark: {
-    primaryColor: "#FFA72A",
-    accentColor: "#458622",
-    backgroundColor: "#504f4d",
-    textColor: "#FFC777",
-    secondaryColor: "#252525"
-  }
+    primaryColor: '#FFA72A',
+    accentColor: '#458622',
+    backgroundColor: '#504f4d',
+    textColor: '#FFC777',
+    secondaryColor: '#252525',
+  },
 };
 
-const { ThemeProvider, withTheme } = createTheming<Theme>(
-  themes.default
-);
+const { ThemeProvider, withTheme } = createTheming<Theme>(themes.default);
 
 type TitleComponentProps = {
   title: string;
@@ -39,7 +37,7 @@ const TitleComponent = ({ title, theme }: TitleComponentProps) => (
   <div
     style={{
       backgroundColor: theme.backgroundColor,
-      color: theme.primaryColor
+      color: theme.primaryColor,
     }}
   >
     {title}
@@ -50,7 +48,10 @@ const ThemedTitle = withTheme(TitleComponent);
 
 const App = () => (
   <ThemeProvider theme={themes.default}>
-    <ThemedTitle title="React Theme Provider" theme={{ primaryColor: 'pink' }} />
+    <ThemedTitle
+      title="React Theme Provider"
+      theme={{ primaryColor: 'pink' }}
+    />
     <ThemedTitle title="Second title" />
   </ThemeProvider>
 );

--- a/typings/hoist-non-react-statics.d.ts
+++ b/typings/hoist-non-react-statics.d.ts
@@ -1,0 +1,80 @@
+// Type definitions for hoist-non-react-statics 3.3
+// Project: https://github.com/mridgway/hoist-non-react-statics#readme
+// Definitions by: JounQin <https://github.com/JounQin>, James Reggio <https://github.com/jamesreggio>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.8
+
+import * as React from 'react';
+
+interface REACT_STATICS {
+  childContextTypes: true;
+  contextType: true;
+  contextTypes: true;
+  defaultProps: true;
+  displayName: true;
+  getDefaultProps: true;
+  getDerivedStateFromError: true;
+  getDerivedStateFromProps: true;
+  mixins: true;
+  propTypes: true;
+  type: true;
+}
+
+interface KNOWN_STATICS {
+  name: true;
+  length: true;
+  prototype: true;
+  caller: true;
+  callee: true;
+  arguments: true;
+  arity: true;
+}
+
+interface MEMO_STATICS {
+  $$typeof: true;
+  compare: true;
+  defaultProps: true;
+  displayName: true;
+  propTypes: true;
+  type: true;
+}
+
+interface FORWARD_REF_STATICS {
+  $$typeof: true;
+  render: true;
+  defaultProps: true;
+  displayName: true;
+  propTypes: true;
+}
+
+declare namespace hoistNonReactStatics {
+  type NonReactStatics<
+    S extends React.ComponentType<any>,
+    C extends {
+      [key: string]: true;
+    } = {}
+  > = {
+    [key in Exclude<
+      keyof S,
+      S extends React.MemoExoticComponent<any>
+        ? keyof MEMO_STATICS | keyof C
+        : S extends React.ForwardRefExoticComponent<any>
+        ? keyof FORWARD_REF_STATICS | keyof C
+        : keyof REACT_STATICS | keyof KNOWN_STATICS | keyof C
+    >]: S[key]
+  };
+}
+
+declare function hoistNonReactStatics<
+  T extends React.ComponentType<any>,
+  S extends React.ComponentType<any>,
+  C extends {
+    [key: string]: true;
+  } = {}
+>(
+  TargetComponent: T,
+  SourceComponent: S,
+  customStatic?: C
+): T & hoistNonReactStatics.NonReactStatics<S, C>;
+
+export = hoistNonReactStatics;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2,7 +2,7 @@
 // TypeScript version 3.0.3
 
 import * as React from 'react';
-import hoistNonReactStatics = require('hoist-non-react-statics');
+import hoistNonReactStatics = require('./hoist-non-react-statics');
 
 type $Without<T, K> = Pick<T, Exclude<keyof T, K>>;
 type $DeepPartial<T> = { [P in keyof T]?: $DeepPartial<T[P]> };

--- a/yarn.lock
+++ b/yarn.lock
@@ -904,14 +904,6 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
-"@types/hoist-non-react-statics@^3.3.1":
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz#1124aafe5118cb591977aeb1ceaaed1070eb039f"
-  integrity sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==
-  dependencies:
-    "@types/react" "*"
-    hoist-non-react-statics "^3.3.0"
-
 "@types/istanbul-lib-coverage@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.0.tgz#2cc2ca41051498382b43157c8227fea60363f94a"
@@ -926,14 +918,6 @@
   version "15.5.8"
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.5.8.tgz#8ae4e0ea205fe95c3901a5a1df7f66495e3a56ce"
   integrity sha512-3AQoUxQcQtLHsK25wtTWIoIpgYjH3vSDroZOUr7PpCHw/jLY1RB9z9E8dBT/OSmwStVgkRNvdh+ZHNiomRieaw==
-
-"@types/react@*":
-  version "16.8.20"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.8.20.tgz#4f633ecbd0a4d56d0ccc50fff6f9321bbcd7d583"
-  integrity sha512-ZLmI+ubSJpfUIlQuULDDrdyuFQORBuGOvNnMue8HeA0GVrAJbWtZQhcBvnBPNRBI/GrfSfrKPFhthzC2SLEtLQ==
-  dependencies:
-    "@types/prop-types" "*"
-    csstype "^2.2.0"
 
 "@types/react@^16.8.8":
   version "16.8.8"


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

This PR fixes an issue where types for hoist-non-react-statics are not correctly resolved when other dependency depends on v2 of @types/hoist-non-react-statics. It is happening in projects using `react-native-paper` and `react-navigation` quite often and this PR aims to fix this by removing @types/hoist-non-react-statics dependency and replacing the types with a copy placed directly inside this project.