### PR TITLE
Adds ability to override theme as second argument in withTheme

### DIFF
--- a/src/createWithTheme.js
+++ b/src/createWithTheme.js
@@ -18,7 +18,7 @@ const createWithTheme = <T: Object, S: $DeepShape<T>>(
   ThemeProvider: ThemeProviderType<T>,
   ThemeContext: React.Context<T>
 ) =>
-  function withTheme(Comp: *) {
+  function withTheme(Comp: *, themeOverride = {}) {
     class ThemedComponent extends React.Component<*> {
       _previous: ?{ a: T, b: ?S, result: T };
 
@@ -44,7 +44,7 @@ const createWithTheme = <T: Object, S: $DeepShape<T>>(
             {theme => (
               <Comp
                 {...rest}
-                theme={this._merge(theme, rest.theme)}
+                theme={this._merge(theme, rest.theme, themeOverride)}
                 ref={_reactThemeProviderForwardedRef}
               />
             )}

--- a/src/createWithTheme.js
+++ b/src/createWithTheme.js
@@ -18,20 +18,21 @@ const createWithTheme = <T: Object, S: $DeepShape<T>>(
   ThemeProvider: ThemeProviderType<T>,
   ThemeContext: React.Context<T>
 ) =>
-  function withTheme(Comp: *, themeOverride = {}) {
+  function withTheme(Comp: *, overrides?: $DeepShape<T>) {
     class ThemedComponent extends React.Component<*> {
-      _previous: ?{ a: T, b: ?S, result: T };
+      _previous: ?{ a: T, b: ?S, c: ?S, result: T };
 
-      _merge = (a: T, b: ?S) => {
+      _merge = (a: T, b: ?S, c: ?S) => {
         const previous = this._previous;
 
-        if (previous && previous.a === a && previous.b === b) {
+        if (previous && previous.a === a && previous.b === b && previous.c === c) {
           return previous.result;
         }
 
-        const result = a && b && a !== b ? deepmerge(a, b) : a || b;
+        let result = a && b && a !== b ? deepmerge(a, b) : a || b;
+        result = result && c && result !== c ? deepmerge(result, c) : result || c;
 
-        this._previous = { a, b, result };
+        this._previous = { a, b, c, result };
 
         return result;
       };
@@ -44,7 +45,7 @@ const createWithTheme = <T: Object, S: $DeepShape<T>>(
             {theme => (
               <Comp
                 {...rest}
-                theme={this._merge(theme, rest.theme, themeOverride)}
+                theme={this._merge(theme, rest.theme, overrides)}
                 ref={_reactThemeProviderForwardedRef}
               />
             )}


### PR DESCRIPTION
### Summary

Hi, I noticed that `useTheme` allows you to (partially) override the theme. There are situations where I'd like to be able to do that with `withTheme`, ie:

```js
export default withTheme(MyScreen, { primary: 'orange' })
```

I have tried to look at ways of solving this otherwise but we don't support hooks yet and this felt like the right way.

The complicated part is how this line is handled:

```js
const result = a && b && a !== b ? deepmerge(a, b) : a || b;
```

My simple solution is;

```js
let result = a && b && a !== b ? deepmerge(a, b) : a || b;
result = result && c && result !== c ? deepmerge(result, c) : result;
```

but I know I can improve on this

### Test plan

My solution is not 100% yet but it's in a working state so I wanted to open up the PR early and get your thoughts

Thank you!
