### PR TITLE
Add `React.HTMLProps` to `withTheme`d components' props interface

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -12,7 +12,7 @@ export type ThemingType<Theme> = {
   withTheme: <Props extends { theme: Theme }, C>(
     WrappedComponent: React.ComponentType<Props> & C
   ) => React.ComponentType<
-    $Without<Props, 'theme'> & { theme?: $DeepPartial<Theme> }
+    $Without<Props, 'theme'> & React.HTMLProps<HTMLElement> & { theme?: $DeepPartial<Theme> }
   > &
     hoistNonReactStatics.NonReactStatics<typeof WrappedComponent>;
   useTheme(overrides?: $DeepPartial<Theme>): Theme;


### PR DESCRIPTION
### Summary

I was trying to pass an `as='h2'` prop into a `withTheme` result, but Typescript was throwing a "missing attributes" error:

```js
// design-system/Text/H2.tsx
export const H2 = withTheme(styled.span`
  font-size: 2.25rem;
`);

// design-system/Text/H2.stories.tsx
import { H2 } from './H2';

export const H2Story = (): JSX.Element => (
  <>
    <H2>I have h2 styles in a span</H2>
    <H2 as='h2'>I have h2 styles in an h2 element</H2>
  </>
);
```

When compiled for prod:
```bash
// $ next build:
ERROR in /Users/anulman/**/H2.stories.tsx(20,9):
20:9 Type '{ children: string; as: string; }' is not assignable to type 'IntrinsicAttributes & Pick<{ theme: { defaultColor: string; screens: { sm: string; md: string; lg: string; xl: string; }; colors: { transparent: string; lilac: string; beige: string; ... 14 more ...; green: { ...; }; }; fonts: { ...; }; }; }, never> & { ...; } & { ...; }'.
  Property 'as' does not exist on type 'IntrinsicAttributes & Pick<{ theme: { defaultColor: string; screens: { sm: string; md: string; lg: string; xl: string; }; colors: { transparent: string; lilac: string; beige: string; ... 14 more ...; green: { ...; }; }; fonts: { ...; }; }; }, never> & { ...; } & { ...; }'.
```

### Test plan

Try running the example above with and without this change. Otherwise Idk how you would test typings, but would be glad to learn!
