### PR TITLE
fix: type $Without does not distribute over discriminated unions

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -4,7 +4,7 @@
 import * as React from 'react';
 import hoistNonReactStatics = require('./hoist-non-react-statics');
 
-type $Without<T, K> = Pick<T, Exclude<keyof T, K>>;
+type $Without<T, K extends keyof any> = T extends any ? Pick<T, Exclude<keyof T, K>> : never;
 type $DeepPartial<T> = { [P in keyof T]?: $DeepPartial<T[P]> };
 
 export type ThemingType<Theme> = {


### PR DESCRIPTION
### Summary
Following up this [this PR](https://github.com/callstack/react-native-paper/pull/2512) in react-native-paper. The current implementation of the type `$Without`  it's not distributing the declarations over discriminated unions. You can read more about [here](https://github.com/microsoft/TypeScript/issues/28791)
