### PR TITLE
chore: change react version in peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "typescript": "^3.3.3333"
   },
   "peerDependencies": {
-    "react": "^16.3.0"
+    "react": ">=16.3.0"
   },
   "dependencies": {
     "deepmerge": "^3.2.0",


### PR DESCRIPTION
 
### Summary

That PR updates react version in peer dependencies.

Installing `react-theme-provider` within `react-native` project `v0.64.2` using npm v7 fails because of the error related to resolving react version in peer dependencies.

![image](https://user-images.githubusercontent.com/22746080/124391352-82d21580-dcf0-11eb-9fa4-c3ca9acc06fe.png)

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

1. create a fresh react-native project - `npx react-native init AwesomeProject`
2. install `react-theme-provider` from the commit which is introducing the fix - `npm install "https://github.com/callstack/react-theme-provider#38d3a3bf609d77dd01aa71248552c9aae425a6af"`

Expect library is installed without any issues.

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
