### PR TITLE
Add publish & upgrade package version Github Actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,20 @@
+name: Publish package to npm
+
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+      - run: yarn
+      - run: yarn prepare
+      - uses: JS-DevTools/npm-publish@v1
+        with:
+          token: ${{ secrets.NPM_AUTH_TOKEN }}
+          access: 'public'

--- a/.github/workflows/update-package-version.yml
+++ b/.github/workflows/update-package-version.yml
@@ -1,0 +1,23 @@
+name: Update package version
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'New package version'
+        required: true
+        default: ''
+jobs:
+  update_package_version:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.GITHUB_PAT }}
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+      - run: git config --global user.email "bot@callstack.io"
+      - run: git config --global user.name "${{ github.actor }}"
+      - run: yarn version --new-version ${{ github.event.inputs.version }}
+      - run: git push --tags
+      - run: git push


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

This PR adds two Github Actions:
- one for automating `npm publish` process when a PR containing a change in `version` field in `package.json` is merged into the `master` branch (it's also checking if the updated version is not published in the npm registry yet)
- second one is a convenience action that can be triggered manually from Github web interface – it will run the upgrade process for the package version and push commit (as long as with new tag created for the specified version) with the version bump to the `master` branch. This will result in triggering the first action automatically and publish new package version in the npm registry.
![image](https://user-images.githubusercontent.com/16213922/136032646-0291e143-500f-4eea-be23-03dece9c623d.png)


### Requisites

These Github Actions need secrets to be added to the repo:
- `NPM_AUTH_TOKEN` – token that will have a capability to publish packages in the `@callstack` namespace in the npm registry.
- `GITHUB_PAT` - Github Personal Access Token is needed to be able to run the second action and push commit from Github Action. After some investigation the default token that's used by the `uses: actions/checkout@v2` unfortunately is resulting in the commits pushed to the `master` branch NOT triggering other Actions. This is intendet behaviour, more context here: https://github.community/t/push-from-action-does-not-trigger-subsequent-action/16854/6

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->

I've tested the actions on forked version of this repo and was able to successfully publish package in the npm. 
