### PR TITLE
Fix ThemeProvider types in React 18

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -8,7 +8,7 @@ type $Without<T, K extends keyof any> = T extends any ? Pick<T, Exclude<keyof T,
 type $DeepPartial<T> = { [P in keyof T]?: $DeepPartial<T[P]> };
 
 export type ThemingType<Theme> = {
-  ThemeProvider: React.ComponentType<{ theme?: Theme, children: React.ReactNode }>;
+  ThemeProvider: React.ComponentType<React.PropsWithChildren<{ theme?: Theme }>>;
   withTheme: <Props extends { theme: Theme }, C>(
     WrappedComponent: React.ComponentType<Props> & C
   ) => React.ComponentType<

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -8,7 +8,7 @@ type $Without<T, K extends keyof any> = T extends any ? Pick<T, Exclude<keyof T,
 type $DeepPartial<T> = { [P in keyof T]?: $DeepPartial<T[P]> };
 
 export type ThemingType<Theme> = {
-  ThemeProvider: React.ComponentType<{ theme?: Theme }>;
+  ThemeProvider: React.ComponentType<{ theme?: Theme, children: React.ReactNode }>;
   withTheme: <Props extends { theme: Theme }, C>(
     WrappedComponent: React.ComponentType<Props> & C
   ) => React.ComponentType<


### PR DESCRIPTION
I added children to the ThemeProvider props type. In React 18 implicit children type was removed and needs to be typed explicitly.
[tweet with more info](https://twitter.com/reactjs/status/1512453230504124420)
[issue](https://github.com/callstack/react-theme-provider/issues/139)