### PR TITLE
feat: accept dynamic theme type in useTheme hook

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -15,7 +15,7 @@ export type ThemingType<Theme> = {
     $Without<Props, 'theme'> & { theme?: $DeepPartial<Theme> }
   > &
     hoistNonReactStatics.NonReactStatics<typeof WrappedComponent>;
-  useTheme(overrides?: $DeepPartial<Theme>): Theme;
+  useTheme<T = Theme>(overrides?: $DeepPartial<T>): T;
 };
 
 export const createTheming: <Theme>(defaultTheme: Theme) => ThemingType<Theme>;


### PR DESCRIPTION
This PR is related to https://github.com/callstack/react-native-paper/pull/3279

### Summary

This change allows to specify custom theme type for the `useTheme` hook. This change is also backward-compatible, so it will act as progressive enhancement for developers if they want to explicitly specify the `useTheme` type