### PR TITLE
fix: add missing type for children in ThemeProvider

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -8,7 +8,7 @@ type $Without<T, K extends keyof any> = T extends any ? Pick<T, Exclude<keyof T,
 type $DeepPartial<T> = { [P in keyof T]?: $DeepPartial<T[P]> };
 
 export type ThemingType<Theme> = {
-  ThemeProvider: React.ComponentType<{ theme?: Theme }>;
+  ThemeProvider: React.ComponentType<{children: React.ReactNode, theme?: Theme }>;
   withTheme: <Props extends { theme: Theme }, C>(
     WrappedComponent: React.ComponentType<Props> & C
   ) => React.ComponentType<


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Adding missing type for `children` in `ThemeProvider` in order to remove the patch-package in `react-native-paper`:

https://github.com/callstack/react-native-paper/blob/main/patches/%40callstack%2Breact-theme-provider%2B3.0.8.patch

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

CI has to be green.

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
